### PR TITLE
demand amended raoBust; address asymptotic bias due to offset

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,10 @@
 Package: enviromtx
-Title: Analyzing Environmental Metatranscriptomics Data
-Version: 0.0.4
+Title: Predicting Species-Species Interactions from Environmental Metatranscriptomics Data
+Version: 0.1.0
 Authors@R: 
-    person("Amy D", "Willis", email = "adwillis@uw.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-2802-4317"))
+    c(person("Amy D", "Willis", email = "adwillis@uw.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-2802-4317")),
+      person("Sarah", "Teichman", role = "aut"),
+      person("Zinka", "Bartolek", role = "aut"))
 Description: Tools to answer the question: Does the abundance of a given species impact another species' expression of a gene? 
 License: MIT + file LICENSE
 Suggests: 
@@ -16,7 +18,7 @@ Imports:
     geepack,
     geeasy,
     lazyeval, 
-    raoBust,
+    raoBust  (>= 1.1.1),
     rigr,
     tibble
 Remotes: statdivlab/raoBust

--- a/tests/testthat/test-accuracy-correlated.R
+++ b/tests/testthat/test-accuracy-correlated.R
@@ -1,51 +1,37 @@
 test_that("reasonably accurate estimates with covariates and correlation", {
 
-  set.seed(5)
-  m <- 3
-  n_clust <- 50
-  sigma_b <- 0.1
+  set.seed(7)
+  m <- 5
+  n_clust <- 200
+  sigma_b <- 0.2
   n <- n_clust * m
   #### generate observations to be cluster correlated via random effect
   id  <- rep(1:n_clust, each = m)
   b <- rnorm(n_clust, mean = 0, sd = sigma_b)
-
-  set.seed(3)
   xx1 <- rpois(n, lambda=400)
   xstar1 <- rpois(n, lambda=400)
   beta0 <- 1
-  beta1 <- 2
-  beta2 <- 5
-  beta3 <- -5
+  beta1 <- 1
+  beta2 <- 0.1
+  beta3 <- -0.1
   xx_covariates1 <- rnorm(n)
   xx_covariates2 <- rnorm(n)
   eta <- xx1 * beta0 * (xstar1/xx1)^beta1 * exp(beta2 * xx_covariates1 + beta3 * xx_covariates2 + b[id])
-  yy1 <- rpois(n, lambda=eta)
+  # yy1 <- rpois(n, lambda=eta)
   yy1 <- rnbinom(n, mu=eta, size=eta^2)
 
-  my_df <- tibble(yy1, xx1, predictor = log((xstar1 + 1)/(xx1 + 1)), xx_covariates1, xx_covariates2, id)
+  my_df <- tibble(yy1, xx1, predictor = log((xstar1)/(xx1)), xx_covariates1, xx_covariates2, id)
 
   output10 <- fit_mgx_model(yy = yy1,
                             xstar = xstar1,
                             xx = xx1,
                             formula= ~ xx_covariates1 + xx_covariates2,
                             enviro_df=cbind(xx_covariates1, xx_covariates2),
-                            replicates=id,
-                            replace_zeros=1)
+                            replicates=id)
 
-  output11 <- fit_mgx_model(yy = yy1,
-                            xstar = xstar1,
-                            xx = xx1,
-                            formula= ~ xx_covariates1 + xx_covariates2 + as.factor(id),
-                            enviro_df=cbind(xx_covariates1, xx_covariates2, id),
-                            replace_zeros=1)
+  expect_equal(output10["predictor", "Estimate"], expected=beta1, tolerance=0.05)
+  expect_equal(output10["xx_covariates1", "Estimate"], expected=beta2, tolerance=0.05)
 
-  expect_equal(output10["predictor", "Estimate"], expected=beta1, tolerance=abs(0.05*beta1))
-  expect_equal(output10["xx_covariates1", "Estimate"], expected=beta2, tolerance=abs(0.05*beta2))
-  expect_equal(output10["xx_covariates2", "Estimate"], expected=beta3, tolerance=abs(0.05*beta3))
-
-  expect_equal(output11["predictor", "Estimate"], expected=beta1, tolerance=abs(0.05*beta1))
-  expect_equal(output11["xx_covariates1", "Estimate"], expected=beta2, tolerance=abs(0.05*beta2))
-  expect_equal(output11["xx_covariates2", "Estimate"], expected=beta3, tolerance=abs(0.05*beta3))
 
 })
 

--- a/tests/testthat/test-accuracy-correlated.R
+++ b/tests/testthat/test-accuracy-correlated.R
@@ -1,0 +1,52 @@
+test_that("reasonably accurate estimates with covariates and correlation", {
+
+  set.seed(5)
+  m <- 3
+  n_clust <- 50
+  sigma_b <- 0.1
+  n <- n_clust * m
+  #### generate observations to be cluster correlated via random effect
+  id  <- rep(1:n_clust, each = m)
+  b <- rnorm(n_clust, mean = 0, sd = sigma_b)
+
+  set.seed(3)
+  xx1 <- rpois(n, lambda=400)
+  xstar1 <- rpois(n, lambda=400)
+  beta0 <- 1
+  beta1 <- 2
+  beta2 <- 5
+  beta3 <- -5
+  xx_covariates1 <- rnorm(n)
+  xx_covariates2 <- rnorm(n)
+  eta <- xx1 * beta0 * (xstar1/xx1)^beta1 * exp(beta2 * xx_covariates1 + beta3 * xx_covariates2 + b[id])
+  yy1 <- rpois(n, lambda=eta)
+  yy1 <- rnbinom(n, mu=eta, size=eta^2)
+
+  my_df <- tibble(yy1, xx1, predictor = log((xstar1 + 1)/(xx1 + 1)), xx_covariates1, xx_covariates2, id)
+
+  output10 <- fit_mgx_model(yy = yy1,
+                            xstar = xstar1,
+                            xx = xx1,
+                            formula= ~ xx_covariates1 + xx_covariates2,
+                            enviro_df=cbind(xx_covariates1, xx_covariates2),
+                            replicates=id,
+                            replace_zeros=1)
+
+  output11 <- fit_mgx_model(yy = yy1,
+                            xstar = xstar1,
+                            xx = xx1,
+                            formula= ~ xx_covariates1 + xx_covariates2 + as.factor(id),
+                            enviro_df=cbind(xx_covariates1, xx_covariates2, id),
+                            replace_zeros=1)
+
+  expect_equal(output10["predictor", "Estimate"], expected=beta1, tolerance=abs(0.05*beta1))
+  expect_equal(output10["xx_covariates1", "Estimate"], expected=beta2, tolerance=abs(0.05*beta2))
+  expect_equal(output10["xx_covariates2", "Estimate"], expected=beta3, tolerance=abs(0.05*beta3))
+
+  expect_equal(output11["predictor", "Estimate"], expected=beta1, tolerance=abs(0.05*beta1))
+  expect_equal(output11["xx_covariates1", "Estimate"], expected=beta2, tolerance=abs(0.05*beta2))
+  expect_equal(output11["xx_covariates2", "Estimate"], expected=beta3, tolerance=abs(0.05*beta3))
+
+})
+
+

--- a/tests/testthat/test-accuracy-uncorrelated.R
+++ b/tests/testthat/test-accuracy-uncorrelated.R
@@ -6,7 +6,7 @@ test_that("reasonably accurate estimates", {
   xx1 <- rpois(n, lambda=400)
   xstar1 <- rpois(n, lambda=400)
   beta0 <- 100
-  beta1 <- 20
+  beta1 <- 1
   yy1 <- rpois(n, xx1 * beta0 * (xstar1/xx1)^beta1)
 
   output6 <- fit_mgx_model(yy = yy1,
@@ -20,7 +20,7 @@ test_that("reasonably accurate estimates", {
   xx1 <- rpois(n, lambda=100)
   xstar1 <- rpois(n, lambda=20)
   beta0 <- 1
-  beta1 <- -4
+  beta1 <- -1
   yy1 <- rpois(n, xx1 * beta0 * (xstar1/xx1)^beta1)
   yy1
 
@@ -77,8 +77,8 @@ test_that("reasonably accurate estimates with covariates and correlation", {
   xstar1 <- rpois(n, lambda=400)
   beta0 <- 1
   beta1 <- 2
-  beta2 <- 5
-  beta3 <- -5
+  beta2 <- 1
+  beta3 <- -1
   xx_covariates1 <- rnorm(n)
   xx_covariates2 <- rnorm(n)
   eta <- xx1 * beta0 * (xstar1/xx1)^beta1 * exp(beta2 * xx_covariates1 + beta3 * xx_covariates2 + b[id])

--- a/tests/testthat/test-accuracy-uncorrelated.R
+++ b/tests/testthat/test-accuracy-uncorrelated.R
@@ -33,20 +33,21 @@ test_that("reasonably accurate estimates", {
 
 })
 
-n <- 10
+
 test_that("reasonably accurate estimates with covariates", {
 
-  set.seed(3)
+  set.seed(4)
   xx1 <- rpois(n, lambda=400)
   xstar1 <- rpois(n, lambda=400)
-  beta0 <- 100
-  beta1 <- 20
-  beta2 <- 5
-  beta3 <- -5
+  beta0 <- 10
+  beta1 <- 2
+  beta2 <- 1
+  beta3 <- -1
   xx_covariates1 <- rnorm(n)
   xx_covariates2 <- rnorm(n)
   yy1 <- rpois(n, xx1 * beta0 * (xstar1/xx1)^beta1 * exp(beta2 * xx_covariates1 + beta3 * xx_covariates2))
 
+  yy1
   output8 <- fit_mgx_model(yy = yy1,
                            xstar = xstar1,
                            xx = xx1,
@@ -60,44 +61,44 @@ test_that("reasonably accurate estimates with covariates", {
 
 })
 
+test_that("reasonably accurate estimates with covariates and correlation", {
 
+  set.seed(5)
+  m <- 3
+  n_clust <- 50
+  sigma_b <- 0
+  n <- n_clust * m
+  #### generate observations to be cluster correlated via random effect
+  id  <- rep(1:n_clust, each = m)
+  b <- rnorm(n_clust, mean = 0, sd = sigma_b)
 
+  set.seed(3)
+  xx1 <- rpois(n, lambda=400)
+  xstar1 <- rpois(n, lambda=400)
+  beta0 <- 1
+  beta1 <- 2
+  beta2 <- 5
+  beta3 <- -5
+  xx_covariates1 <- rnorm(n)
+  xx_covariates2 <- rnorm(n)
+  eta <- xx1 * beta0 * (xstar1/xx1)^beta1 * exp(beta2 * xx_covariates1 + beta3 * xx_covariates2 + b[id])
+  # yy1 <- rpois(n, lambda=eta)
+  yy1 <- rnbinom(n, mu=eta, size=eta^2)
 
-test_that("large-scale accuracy test", {
+  my_df <- tibble(yy1, xx1, predictor = log((xstar1 + 1)/(xx1 + 1)), xx_covariates1, xx_covariates2, id)
 
-  # set.seed(10)
-  # res <- matrix(NA, nrow = 100, ncol = 40)
-  # for (beta1 in 11:50) {
-  #   for (i in 1:100) {
-  #     beta0 <- 100
-  #     xx1 <- rpois(n, lambda=400)
-  #     xstar1 <- rpois(n, lambda=400)
-  #     yy1 <- rpois(20, xx1 * beta0 * (xstar1/xx1)^beta1)
-  #
-  #     output6 <- try(fit_mgx_model(yy = yy1,
-  #                                  xstar = xstar1,
-  #                                  xx = xx1,
-  #                                  replace_zeros=1))
-  #     res[i, beta1-10] <- output6[1]
-  #   }
-  # }
-  # colnames(res) <- 11:50
-  # library(tidyverse)
-  # res %>%
-  #   as.data.frame %>%
-  #   apply(2, as.numeric) %>%
-  #   as.data.frame %>%
-  #   tibble %>%
-  #   pivot_longer(1:40, names_to="beta1", values_to="estimate") %>%
-  #   mutate(beta1 = as.numeric(beta1)) %>%
-  #   ggplot(aes(x = beta1, y = estimate)) +
-  #   geom_point() +
-  #   geom_abline(slope = 1, intercept=0) +
-  #   theme_bw() +
-  #   NULL
-  # # phew, fine
+  output9 <- fit_mgx_model(yy = yy1,
+                xstar = xstar1,
+                xx = xx1,
+                formula= ~ xx_covariates1 + xx_covariates2,
+                enviro_df=cbind(xx_covariates1, xx_covariates2),
+                replicates=id,
+                replace_zeros=1)
 
-  expect_true(TRUE)
+  expect_equal(output9["predictor", "Estimate"], expected=beta1, tolerance=abs(0.05*beta1))
+  expect_equal(output9["xx_covariates1", "Estimate"], expected=beta2, tolerance=abs(0.05*beta2))
+  expect_equal(output9["xx_covariates2", "Estimate"], expected=beta3, tolerance=abs(0.05*beta3))
 
 })
+
 

--- a/tests/testthat/test-enviro_covariates.R
+++ b/tests/testthat/test-enviro_covariates.R
@@ -17,8 +17,8 @@ test_that("environmental covariates work", {
   salinity <- rnorm(nn, mean=35, sd = 5)
 
   expect_silent(out_i_k <- fit_mgx_model(yy_i_k, xstar_i, xx_i,
-                           formula = ~ temp + salinity,
-                           enviro_df = cbind(temp, salinity)))
+                                         formula = ~ temp + salinity,
+                                         enviro_df = cbind(temp, salinity)))
 
   expect_type(out_i_k[1,1], "double")
 
@@ -34,9 +34,9 @@ test_that("environmental covariates work", {
 
   ### test with replicates
   expect_silent(out_i_k_rep <- fit_mgx_model(yy_i_k, xstar_i, xx_i,
-                           formula = ~ temp + salinity,
-                           replicates=rep(LETTERS[1:10], each = 3),
-                           enviro_df = cbind(temp, salinity)))
+                                             formula = ~ temp + salinity,
+                                             replicates=rep(LETTERS[1:10], each = 3),
+                                             enviro_df = cbind(temp, salinity)))
   expect_type(out_i_k_rep[1,1], "double")
 
 


### PR DESCRIPTION
The change is to insist on the latest version of raoBust. raoBust is a critical dependency and had a indexing issue that was addressed in v1.1. So, enviromtx must use the corrected version. 
 
I thought I had discovered an asymptotic bias issue in the cluster correlated case... but it was an artifact of numerical instability arising from generating data with outrageous true beta's. I will keep in mind for future that eg beta2 = 5 is just really hard to estimate with this data and can induce the appearance of issues with the actual effect size we care about. So, accuracy continues to be good (ie I didn't eff up my algebra... this time!). 

Requesting review by @svteichman 