### PR TITLE
Update user inputs so that all vectors must be part of a data frame

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enviromtx
 Title: Predicting Species-Species Interactions from Environmental Metatranscriptomics Data
-Version: 1.1.0
+Version: 1.0.0
 Authors@R: 
     c(person("Amy D", "Willis", email = "adwillis@uw.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-2802-4317")),
       person("Sarah", "Teichman", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enviromtx
 Title: Predicting Species-Species Interactions from Environmental Metatranscriptomics Data
-Version: 0.1.0
+Version: 1.1.0
 Authors@R: 
     c(person("Amy D", "Willis", email = "adwillis@uw.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-2802-4317")),
       person("Sarah", "Teichman", role = "aut"),

--- a/R/fit_mgx_model.R
+++ b/R/fit_mgx_model.R
@@ -9,13 +9,13 @@
 #'
 #' We can then interpret, e.g., \eqn{1.01^{beta_1}} as the multiplicative change in the expression-per-unit-coverage of gene k in species j for 1\% increase in the coverage of species j compared to species j*. With some slightly stronger assumptions about the sampling mechanism, we can also interpret this on the abundance (rather than just coverage) scale
 #'
-#' @param yy vector of abundances of gene k in taxon j
-#' @param xstar vector of abundances of taxon j*
-#' @param xx vector of abundances of taxon j
-#' @param replicates vector that contains the same entries for all observations that are technical replicates. Will be coerced to a factor down the line.
-#' @param formula a formula describing the environmental covariates that should be included in the model. The variable names should be columns in enviro_df
-#' @param enviro_df a data frame or tibble with columns containing environmental covariates that should be included in the model,
-#' @param wts vector of nonnegative weights. Could be sequencing depth to put more emphasis on deeply sequenced samples
+#' @param enviro_df a data frame or tibble with columns containing relevant abundances, environmental covariates that should be included in the model, and optionally replicate information
+#' @param yy column of `enviro_df` containing abundances of gene k in taxon j. Default is "yy".
+#' @param xstar column of `enviro_df` containing abundances of taxon j*. Default is "xstar".
+#' @param xx column of `enviro_df` containing abundances of taxon j. Default is "xx".
+#' @param replicates column of `enviro_df` containing the same entries for all observations that are technical replicates. Will be coerced to a factor down the line. Default is `NULL`.
+#' @param formula a formula describing the environmental covariates that should be included in the model. The variable names should be columns in `enviro_df`
+#' @param wts column of `enviro_df` containing nonnegative weights. Could be sequencing depth to put more emphasis on deeply sequenced samples. Default is `NULL`.
 #' @param replace_zeros what to do with zeros in the denominator \eqn{X_{ij}}. Options include "minimum" or pseudocount numeric value (eg. 1)
 #' @param use_jack_se when replicates are given, if TRUE will use jackknife standard errors instead of sandwich standard errors. This is recommended when
 #' there is a small number of clusters.
@@ -30,64 +30,95 @@
 #' @import geepack
 #' @import geeasy
 #'
+#' @examples
+#' my_df <- data.frame(xx = rpois(20, lambda = 400),
+#'                     xstar = rpois(20, lambda = 400),
+#'                     treatment = rep(0:1, each = 10),
+#'                     id = rep(1:4, 5))
+#' my_df$yy <- rpois(20, my_df$xx * 10 * (my_df$xstar / my_df$xx)^2)
+#' fit_mgx_model(enviro_df = my_df, replicates = "id", formula = ~ treatment)
 #'
 #' @export
 fit_mgx_model <- function(
-    yy,
-    xstar,
-    xx,
+    enviro_df,
+    yy = "yy",
+    xstar = "xstar",
+    xx = "xx",
     replicates = NULL,
     formula = NULL,
-    enviro_df = NULL,
     wts = NULL,
     replace_zeros = "minimum",
     use_jack_se = FALSE,
     cluster_corr_coef = NULL
 ) {
 
+  # first, check that everything is in enviro_df
+  if (!(is.character(yy) &
+        is.character(xstar) &
+        is.character(xx))) {
+    stop("`yy`, `xstar`, and `xx` must be character objects giving the name of the column in `enviro_df` containing each relevant vector, not the vectors themselves.")
+  }
+  missing_args <- which(!(c(yy, xstar, xx) %in% names(enviro_df)))
+  if (length(missing_args) > 0) {
+    stop(paste0("The column names ", c(yy, xstar, xx)[missing_args], " do not appear in enviro_df. Please include them and then rerun this function. "))
+  }
+  if (!is.null(replicates)) {
+    if (!is.character(replicates)) {
+      stop("`replicates` argument must be a column name in `enviro_df` if it is included.")
+    } else {
+      if (!(replicates %in% names(enviro_df))) {
+        stop("`replicates` argument must be a column name in `enviro_df` if it is included.")
+      }
+    }
+  }
+  if (!is.null(wts)) {
+    if (!is.character(wts)) {
+      stop("`wts` argument must be a column name in `enviro_df` if it is included.")
+    } else {
+      if (!(wts %in% names(enviro_df))) {
+        stop("`wts` argument must be a column name in `enviro_df` if it is included.")
+      }
+    }
+  }
+
   # Setting pseudocounts for xx and xstar
   if (replace_zeros == "minimum") {
-    xx[xx == 0] <- min(xx[xx > 0]) # cheap pseudocount - take minimum
+    enviro_df[[xx]][enviro_df[[xx]] == 0] <- min(enviro_df[[xx]][enviro_df[[xx]] > 0]) # cheap pseudocount - take minimum
   } else if (is.numeric(replace_zeros)) {
     if (replace_zeros == 0) stop("You've told me to replace zeroes with zero!")
-    xx[xx == 0] <- replace_zeros
+    enviro_df[[xx]][enviro_df[[xx]] == 0] <- replace_zeros
   }
-  if (any(xx == 0)) stop("There are zeros in xx and you haven't told me what to do with them!")
+  if (any(enviro_df[[xx]] == 0)) stop("There are zeros in enviro_df$xx and you haven't told me what to do with them!")
 
   if (replace_zeros == "minimum") {
-    xstar[xstar == 0] <- min(xstar[xstar > 0]) # cheap pseudocount - take minimum
+    enviro_df[[xstar]][enviro_df[[xstar]] == 0] <- min(enviro_df[[xstar]][enviro_df[[xstar]] > 0]) # cheap pseudocount - take minimum
   } else if (is.numeric(replace_zeros)) {
     if (replace_zeros == 0) stop("You've told me to replace zeroes with zero!")
-    xstar[xstar == 0] <- replace_zeros
+    enviro_df[[xstar]][enviro_df[[xstar]] == 0] <- replace_zeros
   }
 
-  if (any(xstar == 0)) stop("There are zeros in xstar and you haven't told me what to do with them!")
+  if (any(enviro_df[[xstar]] == 0)) stop("There are zeros in xstar and you haven't told me what to do with them!")
 
   ################################################
   ## set up the data for fitting
   ################################################
 
-  predictor <- log(xstar / xx)
+  predictor <- log(enviro_df[[xstar]] / enviro_df[[xx]])
 
-  if (!is.null(formula) & !is.null(enviro_df)) {
+  if (is.null(formula)) {
 
     ## formula is yy ~ log(x*/x) + salinity + iron
-    my_formula <- lazyeval::f_new(lhs=quote(yy),
-                                  rhs = lazyeval::as_call(paste("predictor +", as.character(formula)[2])))
-    my_df <- dplyr::bind_cols(tibble::tibble(yy, xstar, xx, predictor), enviro_df)
-
-  } else if (xor(is.null(formula), is.null(enviro_df))) {
-
-    stop("One of `formula` or `enviro_df` is missing. Please correct this and try again.")
-
-  } else if (is.null(formula) & is.null(enviro_df)) {
-
-    my_df <- tibble::tibble(yy, xstar, xx, predictor)
-    my_formula <- yy ~ predictor
-
+    formula <- lazyeval::f_new(lhs=lazyeval::as_call(yy),
+                               rhs = lazyeval::as_call("predictor"))
+    my_df <- dplyr::bind_cols(tibble::tibble(predictor), enviro_df)
 
   } else {
-    stop("Ergh, there is an error and it is Amy's fault.")
+
+    ## formula is yy ~ log(x*/x) + salinity + iron
+    formula <- lazyeval::f_new(lhs=lazyeval::as_call(yy),
+                               rhs = lazyeval::as_call(paste("predictor +", as.character(formula)[2])))
+    my_df <- dplyr::bind_cols(tibble::tibble(predictor), enviro_df)
+
   }
 
   if(any(apply(my_df, 2, is.infinite))) {
@@ -96,9 +127,12 @@ fit_mgx_model <- function(
   }
 
   if (is.null(wts)) {
-    wts <- rep(1L, nrow(data.frame(my_df)))
+    my_df$wts <- rep(1L, nrow(my_df))
+    wts <- "wts"
   }
-  my_df$wts <- wts
+
+  my_df$offset <- log(my_df[[xx]])
+  offset <- "offset"
 
   ################################################
   ## fit the model with Poisson regression
@@ -108,27 +142,29 @@ fit_mgx_model <- function(
   ## log(E[Y]) = log(X) + beta0 + beta1 * log(X^*/X) + beta2 * salinity + beta3 * iron
   ## E[Y]/X = gamma0 * (X^*/X)^beta1 * e^(beta2*salinity + beta3*iron)
 
-  # raoBust_out <- eval(rlang::expr(raoBust::glm_test( TODO )),
-  #                     envir = .env)
-
   if (is.null(replicates)) {
-    raoBust_out <- raoBust::glm_test(formula = my_formula,
-                                     offset=log(xx),
-                                     family=stats::poisson(link="log"),
-                                     data=my_df,
-                                     weights=wts)$coef_tab
+    raoBust_out <- raoBust::glm_test(formula = formula,
+                                     offset = offset,
+                                     family = stats::poisson(link = "log"),
+                                     data = my_df,
+                                     weights = wts)$coef_tab
   } else {
-    if (!all(wts == 1L)) {
+    if (!all(my_df[[wts]] == 1L)) {
       warning("Run this by Amy; not sure what this is doing off-the-cuff")
     }
-    my_df$id <- replicates
+    if (replicates != "id") {
+      my_df$id <- my_df[[replicates]]
+      my_df[[replicates]] <- NULL
+      id <- "id"
+    } else {
+      id <- "id"
+    }
 
-    raoBust_out <- raoBust::gee_test(formula = my_formula,
-                                     offset=log(xx),
-                                     family=stats::poisson(link="log"),
-                                     id="id",
-                                     # weights=wts,
-                                     data=my_df,
+    raoBust_out <- raoBust::gee_test(formula = formula,
+                                     offset = offset,
+                                     family = stats::poisson(link="log"),
+                                     id = id,
+                                     data = my_df,
                                      use_jack_se = use_jack_se,
                                      cluster_corr_coef = cluster_corr_coef)$coef_tab
   }

--- a/R/fit_mgx_model.R
+++ b/R/fit_mgx_model.R
@@ -1,26 +1,26 @@
-#' Fit model for fixed gene k, taxon j, taxon j*
+#' Estimate the difference in expression-per-unit-abundance of a gene expressed by a responder taxon as a function of the abundance of a companion taxon
 #'
-#' We would like to estimate beta1 in the model
-#' \eqn{Y_ijk ~ Poisson(X_ij * c * (X_{ij*} / X_{ij})^{beta_1})}
+#' We would like to estimate the \eqn{\beta} parameters in the model
+#' \eqn{\text{average } Y_{ijk} = X_{ij} \times c \times (X_{ij^*} / X_{ij})^{\beta_1} \times e^{\beta_2 W_{i1} + \beta_3 W_{i2} + \ldots + \beta_p W_{i,p-1}}},
 #' where
-#' \eqn{Y_{ijk}} refers to data about the abundance of gene k expressed by taxon j in sample i
-#' \eqn{X_{ij}} refers to data about the abundance of taxon j in sample i
-#' \eqn{X_{ij*}} refers to data about the abundance of taxon j* in sample i
+#' \eqn{Y_{ijk}} refers to the observed abundance of gene \eqn{k} expressed by taxon \eqn{j} in sample \eqn{i},
+#' \eqn{X_{ij}} refers to the observed abundance of taxon \eqn{j} in sample \eqn{i},
+#' \eqn{X_{ij^*}} refers to the observed abundance of taxon \eqn{j^*} in sample \eqn{i}, and
+#' \eqn{W_{im}} is the value of abiotic covariate \eqn{m} observed in sample \eqn{i}.
+#' We can interpret \eqn{1.01^{\beta_1}} as the multiplicative change in the expression-per-unit-coverage of gene \eqn{k} in species \eqn{j} for 1\\% increase in the coverage of species \eqn{j} compared to species \eqn{j^*}. With some slightly stronger assumptions about the sampling mechanism, we can also interpret this on the true cell abundance scale (rather than just the coverage scale).
 #'
-#' We can then interpret, e.g., \eqn{1.01^{beta_1}} as the multiplicative change in the expression-per-unit-coverage of gene k in species j for 1\% increase in the coverage of species j compared to species j*. With some slightly stronger assumptions about the sampling mechanism, we can also interpret this on the abundance (rather than just coverage) scale
-#'
-#' @param enviro_df a data frame or tibble with columns containing relevant abundances, environmental covariates that should be included in the model, and optionally replicate information
-#' @param yy column of `enviro_df` containing abundances of gene k in taxon j. Default is "yy".
-#' @param xstar column of `enviro_df` containing abundances of taxon j*. Default is "xstar".
-#' @param xx column of `enviro_df` containing abundances of taxon j. Default is "xx".
-#' @param replicates column of `enviro_df` containing the same entries for all observations that are technical replicates. Will be coerced to a factor down the line. Default is `NULL`.
-#' @param formula a formula describing the environmental covariates that should be included in the model. The variable names should be columns in `enviro_df`
-#' @param wts column of `enviro_df` containing nonnegative weights. Could be sequencing depth to put more emphasis on deeply sequenced samples. Default is `NULL`.
-#' @param replace_zeros what to do with zeros in the denominator \eqn{X_{ij}}. Options include "minimum" or pseudocount numeric value (eg. 1)
-#' @param use_jack_se when replicates are given, if TRUE will use jackknife standard errors instead of sandwich standard errors. This is recommended when
-#' there is a small number of clusters.
-#' @param cluster_corr_coef when replicates are given, estimated value of the within-cluster correlation coefficient. This will only be used when gee estimation in `raoBust::gee_test` fails, and instead
-#' estimation is performed with a glm. This is set to NULL by default.
+#' @param enviro_df A data frame or tibble with columns containing the relevant variables, and rows denoting the observations. Columns must contain the following data: observed gene expression data, taxon abundance data, environmental covariates, and (optionally) technical replicate information.
+#' @param yy The name of the column in `enviro_df` containing the expression data for a gene expressed by the responder taxon. Default is "yy". Expression data could be in the form of coverage, counts, etc. See vignettes for details on acceptable and suggested datatypes and preprocessing ("normalizations"). In the above notation, this corresponds to the expression of gene \eqn{k} expressed by taxon \eqn{j}.
+#' @param xx The name of the column in `enviro_df` containing abundances of the responder taxon. Default is "xx". In the above notation, this corresponds to the abundance of taxon \eqn{j}.
+#' @param xstar The name of the column in `enviro_df` containing abundances of the companion taxon. Default is "xstar". In the above notation, this corresponds to the abundance of  taxon \eqn{j^*}.
+#' @param replicates The name of the column in `enviro_df` containing technical replicate information. Entries in this column should be the same within observations that are technical replicates. Will be coerced to a factor internally. Default is `NULL`.
+#' @param formula A formula describing the environmental covariates that should be included in the model. The variable names should be columns in `enviro_df`
+#' @param wts The name of the column in `enviro_df` containing nonnegative weights for the observation. Could be sequencing depth to put more emphasis on deeply sequenced samples. Default is `NULL`.
+#' @param replace_zeros What to replace zeros with in the denominator \eqn{X_{ij}}. Options include "minimum" (replace with the smallest value) or pseudocount numeric value (eg. 1). Default is "minimum".
+#' @param use_jack_se Boolean indicating whether to use jackknife standard errors (TRUE) rather than sandwich standard errors (FALSE). Only relevant if technical replicates are included. Jackknife standard errors are recommended when
+#' there are a small number of observations. Defaults to FALSE.
+#' @param cluster_corr_coef When technical replicates are given, the estimated value of the within-cluster correlation coefficient. This will only be used when GEE estimation in `raoBust::gee_test` fails, and
+#' estimation is performed with a glm. Defaults to NULL by default (no robust score test is returned).
 #'
 #' @importFrom tibble tibble
 #' @importFrom dplyr bind_cols
@@ -98,6 +98,11 @@ fit_mgx_model <- function(
   }
 
   if (any(enviro_df[[xstar]] == 0)) stop("There are zeros in xstar and you haven't told me what to do with them!")
+
+  if (any(enviro_df[[xstar]] < 0)) stop("You gave negative abundance data for `xstar`. This doesn't make sense.")
+  if (any(enviro_df[[xx]] < 0)) stop("You gave negative abundance data for `xx`. This doesn't make sense.")
+  if (any(enviro_df[[yy]] < 0)) stop("You gave negative expression data `yy`. This doesn't make sense.")
+
 
   ################################################
   ## set up the data for fitting

--- a/R/fit_mgx_model.R
+++ b/R/fit_mgx_model.R
@@ -131,6 +131,12 @@ fit_mgx_model <- function(
 
   }
 
+  # check for "id" in formula
+  form_terms <- trimws(unlist(strsplit(x = as.character(formula)[3], split = "\\+")))
+  if ("id" %in% form_terms) {
+    stop("You have a covariate called 'id' in your formula. This is a protected term in `fit_mgx_model`, please use a different name for this covariate")
+  }
+
   # check for infinite values in my_df
   if (!is.null(wts)) {
     if (any(is.infinite(my_df[[wts]]))) {

--- a/R/fit_mgx_model.R
+++ b/R/fit_mgx_model.R
@@ -7,15 +7,15 @@
 #' \eqn{X_{ij}} refers to the observed abundance of taxon \eqn{j} in sample \eqn{i},
 #' \eqn{X_{ij^*}} refers to the observed abundance of taxon \eqn{j^*} in sample \eqn{i}, and
 #' \eqn{W_{im}} is the value of abiotic covariate \eqn{m} observed in sample \eqn{i}.
-#' We can interpret \eqn{1.01^{\beta_1}} as the multiplicative change in the expression-per-unit-coverage of gene \eqn{k} in species \eqn{j} for 1\\% increase in the coverage of species \eqn{j} compared to species \eqn{j^*}. With some slightly stronger assumptions about the sampling mechanism, we can also interpret this on the true cell abundance scale (rather than just the coverage scale).
+#' We can interpret \eqn{1.01^{\beta_1}} as the multiplicative change in the expression-per-unit-coverage of gene \eqn{k} in species \eqn{j} for 1\\% increase in the coverage of species \eqn{j} compared to species \eqn{j^*}, when comparing samples with the same values of the abiotic covariates. With some slightly stronger assumptions about the sampling mechanism, we can also interpret this on the true cell abundance scale (rather than just the coverage scale).
 #'
 #' @param enviro_df A data frame or tibble with columns containing the relevant variables, and rows denoting the observations. Columns must contain the following data: observed gene expression data, taxon abundance data, environmental covariates, and (optionally) technical replicate information.
 #' @param yy The name of the column in `enviro_df` containing the expression data for a gene expressed by the responder taxon. Default is "yy". Expression data could be in the form of coverage, counts, etc. See vignettes for details on acceptable and suggested datatypes and preprocessing ("normalizations"). In the above notation, this corresponds to the expression of gene \eqn{k} expressed by taxon \eqn{j}.
 #' @param xx The name of the column in `enviro_df` containing abundances of the responder taxon. Default is "xx". In the above notation, this corresponds to the abundance of taxon \eqn{j}.
 #' @param xstar The name of the column in `enviro_df` containing abundances of the companion taxon. Default is "xstar". In the above notation, this corresponds to the abundance of  taxon \eqn{j^*}.
-#' @param replicates The name of the column in `enviro_df` containing technical replicate information. Entries in this column should be the same within observations that are technical replicates. Will be coerced to a factor internally. Default is `NULL`.
+#' @param replicates The name of the column in `enviro_df` containing technical replicate information. Entries in this column should be the same within observations that are technical replicates. Will be coerced to a factor internally. Default is `NULL` (no samples have technical replicates; all samples are independent).
 #' @param formula A formula describing the environmental covariates that should be included in the model. The variable names should be columns in `enviro_df`
-#' @param wts The name of the column in `enviro_df` containing nonnegative weights for the observation. Could be sequencing depth to put more emphasis on deeply sequenced samples. Default is `NULL`.
+#' @param wts The name of the column in `enviro_df` containing nonnegative weights for the observation. Could be sequencing depth to put more emphasis on deeply sequenced samples. Default is `NULL` (all observations contribute equally to the likelihood).
 #' @param replace_zeros What to replace zeros with in the denominator \eqn{X_{ij}}. Options include "minimum" (replace with the smallest value) or pseudocount numeric value (eg. 1). Default is "minimum".
 #' @param use_jack_se Boolean indicating whether to use jackknife standard errors (TRUE) rather than sandwich standard errors (FALSE). Only relevant if technical replicates are included. Jackknife standard errors are recommended when
 #' there are a small number of observations. Defaults to FALSE.
@@ -104,6 +104,11 @@ fit_mgx_model <- function(
   if (any(enviro_df[[yy]] < 0)) stop("You gave negative expression data `yy`. This doesn't make sense.")
 
 
+  if (any(is.infinite(enviro_df[[xstar]]))) stop("You gave infinite abundance data for `xstar`. This doesn't make sense.")
+  if (any(is.infinite(enviro_df[[xx]]))) stop("You gave infinite abundance data for `xx`. This doesn't make sense.")
+  if (any(is.infinite(enviro_df[[yy]]))) stop("You gave infinite abundance data for `yy`. This doesn't make sense.")
+
+
   ################################################
   ## set up the data for fitting
   ################################################
@@ -125,11 +130,11 @@ fit_mgx_model <- function(
     my_df <- dplyr::bind_cols(tibble::tibble(predictor), enviro_df)
 
   }
-
-  if(any(apply(my_df, 2, is.infinite))) {
-    print(my_df, n = nrow(my_df))
-    stop("Infinities in my_df? Amy's fault.")
-  }
+#
+#   if(any(apply(my_df, 2, is.infinite))) {
+#     print(my_df, n = nrow(my_df))
+#     stop("Infinities in my_df? Amy's fault.")
+#   }
 
   if (is.null(wts)) {
     my_df$wts <- rep(1L, nrow(my_df))

--- a/R/fit_mgx_model.R
+++ b/R/fit_mgx_model.R
@@ -130,11 +130,24 @@ fit_mgx_model <- function(
     my_df <- dplyr::bind_cols(tibble::tibble(predictor), enviro_df)
 
   }
-#
-#   if(any(apply(my_df, 2, is.infinite))) {
-#     print(my_df, n = nrow(my_df))
-#     stop("Infinities in my_df? Amy's fault.")
-#   }
+
+  # check for infinite values in my_df
+  if (!is.null(wts)) {
+    if (any(is.infinite(my_df[[wts]]))) {
+      stop("At least one weight provided is infinite. Please fix this and then rerun.")
+    }
+  }
+  if (!is.null(replicates)) {
+    if (any(is.infinite(my_df[[replicates]]))) {
+      stop("At least one replicate provided is infinite. Please fix this and then rerun.")
+    }
+  }
+  covs <- all.vars(update(formula, . ~ .))[-1]
+  for (i in 1:length(covs)) {
+    if (any(is.infinite(my_df[[covs[i]]]))) {
+      stop(paste0("At least one value of covariate ", covs[i], " is infinite. Please fix this and rerun."))
+    }
+  }
 
   if (is.null(wts)) {
     my_df$wts <- rep(1L, nrow(my_df))

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,14 +39,15 @@ This is a basic example which shows you how to fit the model. More documentation
 library(enviromtx)
 n <- 10
 set.seed(3)
-xx1 <- rpois(n, lambda=400)
-xstar1 <- rpois(n, lambda=400)
+df <- data.frame(xx1 = rpois(n, lambda=400),
+                 xstar1 = rpois(n, lambda=400))
 beta0 <- 100
 beta1 <- 20
-yy1 <- rpois(n, xx1 * beta0 * (xstar1/xx1)^beta1)
+df$yy1 <- rpois(n, xx1 * beta0 * (xstar1/xx1)^beta1)
 
-fit_mgx_model(yy = yy1,
-              xstar = xstar1,
-              xx = xx1,
+fit_mgx_model(enviro_df = df, 
+              yy = "yy1",
+              xstar = "xstar1",
+              xx = "xx1",
               replace_zeros=1)
 ``` 

--- a/man/fit_mgx_model.Rd
+++ b/man/fit_mgx_model.Rd
@@ -5,12 +5,12 @@
 \title{Fit model for fixed gene k, taxon j, taxon j*}
 \usage{
 fit_mgx_model(
-  yy,
-  xstar,
-  xx,
+  enviro_df,
+  yy = "yy",
+  xstar = "xstar",
+  xx = "xx",
   replicates = NULL,
   formula = NULL,
-  enviro_df = NULL,
   wts = NULL,
   replace_zeros = "minimum",
   use_jack_se = FALSE,
@@ -18,19 +18,19 @@ fit_mgx_model(
 )
 }
 \arguments{
-\item{yy}{vector of abundances of gene k in taxon j}
+\item{enviro_df}{a data frame or tibble with columns containing relevant abundances, environmental covariates that should be included in the model, and optionally replicate information}
 
-\item{xstar}{vector of abundances of taxon j*}
+\item{yy}{column of \code{enviro_df} containing abundances of gene k in taxon j. Default is "yy".}
 
-\item{xx}{vector of abundances of taxon j}
+\item{xstar}{column of \code{enviro_df} containing abundances of taxon j*. Default is "xstar".}
 
-\item{replicates}{vector that contains the same entries for all observations that are technical replicates. Will be coerced to a factor down the line.}
+\item{xx}{column of \code{enviro_df} containing abundances of taxon j. Default is "xx".}
 
-\item{formula}{a formula describing the environmental covariates that should be included in the model. The variable names should be columns in enviro_df}
+\item{replicates}{column of \code{enviro_df} containing the same entries for all observations that are technical replicates. Will be coerced to a factor down the line. Default is \code{NULL}.}
 
-\item{enviro_df}{a data frame or tibble with columns containing environmental covariates that should be included in the model,}
+\item{formula}{a formula describing the environmental covariates that should be included in the model. The variable names should be columns in \code{enviro_df}}
 
-\item{wts}{vector of nonnegative weights. Could be sequencing depth to put more emphasis on deeply sequenced samples}
+\item{wts}{column of \code{enviro_df} containing nonnegative weights. Could be sequencing depth to put more emphasis on deeply sequenced samples. Default is \code{NULL}.}
 
 \item{replace_zeros}{what to do with zeros in the denominator \eqn{X_{ij}}. Options include "minimum" or pseudocount numeric value (eg. 1)}
 
@@ -50,4 +50,13 @@ where
 }
 \details{
 We can then interpret, e.g., \eqn{1.01^{beta_1}} as the multiplicative change in the expression-per-unit-coverage of gene k in species j for 1\\% increase in the coverage of species j compared to species j*. With some slightly stronger assumptions about the sampling mechanism, we can also interpret this on the abundance (rather than just coverage) scale
+}
+\examples{
+my_df <- data.frame(xx = rpois(20, lambda = 400),
+                    xstar = rpois(20, lambda = 400),
+                    treatment = rep(0:1, each = 10),
+                    id = rep(1:4, 5))
+my_df$yy <- rpois(20, my_df$xx * 10 * (my_df$xstar / my_df$xx)^2)
+fit_mgx_model(enviro_df = my_df, replicates = "id", formula = ~ treatment)
+
 }

--- a/man/fit_mgx_model.Rd
+++ b/man/fit_mgx_model.Rd
@@ -26,13 +26,13 @@ fit_mgx_model(
 
 \item{xx}{The name of the column in \code{enviro_df} containing abundances of the responder taxon. Default is "xx". In the above notation, this corresponds to the abundance of taxon \eqn{j}.}
 
-\item{replicates}{The name of the column in \code{enviro_df} containing technical replicate information. Entries in this column should be the same within observations that are technical replicates. Will be coerced to a factor internally. Default is \code{NULL}.}
+\item{replicates}{The name of the column in \code{enviro_df} containing technical replicate information. Entries in this column should be the same within observations that are technical replicates. Will be coerced to a factor internally. Default is \code{NULL} (no samples have technical replicates; all samples are independent).}
 
-\item{formula}{a formula describing the environmental covariates that should be included in the model. The variable names should be columns in \code{enviro_df}}
+\item{formula}{A formula describing the environmental covariates that should be included in the model. The variable names should be columns in \code{enviro_df}}
 
-\item{wts}{The name of the column in \code{enviro_df} containing nonnegative weights for the observation. Could be sequencing depth to put more emphasis on deeply sequenced samples. Default is \code{NULL}.}
+\item{wts}{The name of the column in \code{enviro_df} containing nonnegative weights for the observation. Could be sequencing depth to put more emphasis on deeply sequenced samples. Default is \code{NULL} (all observations contribute equally to the likelihood).}
 
-\item{replace_zeros}{what to do with zeros in the denominator \eqn{X_{ij}}. Options include "minimum" (replace with the smallest value) or pseudocount numeric value (eg. 1). Default is "minimum".}
+\item{replace_zeros}{What to replace zeros with in the denominator \eqn{X_{ij}}. Options include "minimum" (replace with the smallest value) or pseudocount numeric value (eg. 1). Default is "minimum".}
 
 \item{use_jack_se}{Boolean indicating whether to use jackknife standard errors (TRUE) rather than sandwich standard errors (FALSE). Only relevant if technical replicates are included. Jackknife standard errors are recommended when
 there are a small number of observations. Defaults to FALSE.}
@@ -48,7 +48,7 @@ where
 \eqn{X_{ij}} refers to the observed abundance of taxon \eqn{j} in sample \eqn{i},
 \eqn{X_{ij^*}} refers to the observed abundance of taxon \eqn{j^*} in sample \eqn{i}, and
 \eqn{W_{im}} is the value of abiotic covariate \eqn{m} observed in sample \eqn{i}.
-We can interpret \eqn{1.01^{\beta_1}} as the multiplicative change in the expression-per-unit-coverage of gene \eqn{k} in species \eqn{j} for 1\\\% increase in the coverage of species \eqn{j} compared to species \eqn{j^*}. With some slightly stronger assumptions about the sampling mechanism, we can also interpret this on the true cell abundance scale (rather than just the coverage scale).
+We can interpret \eqn{1.01^{\beta_1}} as the multiplicative change in the expression-per-unit-coverage of gene \eqn{k} in species \eqn{j} for 1\\\% increase in the coverage of species \eqn{j} compared to species \eqn{j^*}, when comparing samples with the same values of the abiotic covariates. With some slightly stronger assumptions about the sampling mechanism, we can also interpret this on the true cell abundance scale (rather than just the coverage scale).
 }
 \examples{
 my_df <- data.frame(xx = rpois(20, lambda = 400),

--- a/man/fit_mgx_model.Rd
+++ b/man/fit_mgx_model.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/fit_mgx_model.R
 \name{fit_mgx_model}
 \alias{fit_mgx_model}
-\title{Fit model for fixed gene k, taxon j, taxon j*}
+\title{Estimate the difference in expression-per-unit-abundance of a gene expressed by a responder taxon as a function of the abundance of a companion taxon}
 \usage{
 fit_mgx_model(
   enviro_df,
@@ -18,38 +18,37 @@ fit_mgx_model(
 )
 }
 \arguments{
-\item{enviro_df}{a data frame or tibble with columns containing relevant abundances, environmental covariates that should be included in the model, and optionally replicate information}
+\item{enviro_df}{A data frame or tibble with columns containing the relevant variables, and rows denoting the observations. Columns must contain the following data: observed gene expression data, taxon abundance data, environmental covariates, and (optionally) technical replicate information.}
 
-\item{yy}{column of \code{enviro_df} containing abundances of gene k in taxon j. Default is "yy".}
+\item{yy}{The name of the column in \code{enviro_df} containing the expression data for a gene expressed by the responder taxon. Default is "yy". Expression data could be in the form of coverage, counts, etc. See vignettes for details on acceptable and suggested datatypes and preprocessing ("normalizations"). In the above notation, this corresponds to the expression of gene \eqn{k} expressed by taxon \eqn{j}.}
 
-\item{xstar}{column of \code{enviro_df} containing abundances of taxon j*. Default is "xstar".}
+\item{xstar}{The name of the column in \code{enviro_df} containing abundances of the companion taxon. Default is "xstar". In the above notation, this corresponds to the abundance of  taxon \eqn{j^*}.}
 
-\item{xx}{column of \code{enviro_df} containing abundances of taxon j. Default is "xx".}
+\item{xx}{The name of the column in \code{enviro_df} containing abundances of the responder taxon. Default is "xx". In the above notation, this corresponds to the abundance of taxon \eqn{j}.}
 
-\item{replicates}{column of \code{enviro_df} containing the same entries for all observations that are technical replicates. Will be coerced to a factor down the line. Default is \code{NULL}.}
+\item{replicates}{The name of the column in \code{enviro_df} containing technical replicate information. Entries in this column should be the same within observations that are technical replicates. Will be coerced to a factor internally. Default is \code{NULL}.}
 
 \item{formula}{a formula describing the environmental covariates that should be included in the model. The variable names should be columns in \code{enviro_df}}
 
-\item{wts}{column of \code{enviro_df} containing nonnegative weights. Could be sequencing depth to put more emphasis on deeply sequenced samples. Default is \code{NULL}.}
+\item{wts}{The name of the column in \code{enviro_df} containing nonnegative weights for the observation. Could be sequencing depth to put more emphasis on deeply sequenced samples. Default is \code{NULL}.}
 
-\item{replace_zeros}{what to do with zeros in the denominator \eqn{X_{ij}}. Options include "minimum" or pseudocount numeric value (eg. 1)}
+\item{replace_zeros}{what to do with zeros in the denominator \eqn{X_{ij}}. Options include "minimum" (replace with the smallest value) or pseudocount numeric value (eg. 1). Default is "minimum".}
 
-\item{use_jack_se}{when replicates are given, if TRUE will use jackknife standard errors instead of sandwich standard errors. This is recommended when
-there is a small number of clusters.}
+\item{use_jack_se}{Boolean indicating whether to use jackknife standard errors (TRUE) rather than sandwich standard errors (FALSE). Only relevant if technical replicates are included. Jackknife standard errors are recommended when
+there are a small number of observations. Defaults to FALSE.}
 
-\item{cluster_corr_coef}{when replicates are given, estimated value of the within-cluster correlation coefficient. This will only be used when gee estimation in \code{raoBust::gee_test} fails, and instead
-estimation is performed with a glm. This is set to NULL by default.}
+\item{cluster_corr_coef}{When technical replicates are given, the estimated value of the within-cluster correlation coefficient. This will only be used when GEE estimation in \code{raoBust::gee_test} fails, and
+estimation is performed with a glm. Defaults to NULL by default (no robust score test is returned).}
 }
 \description{
-We would like to estimate beta1 in the model
-\eqn{Y_ijk ~ Poisson(X_ij * c * (X_{ij*} / X_{ij})^{beta_1})}
+We would like to estimate the \eqn{\beta} parameters in the model
+\eqn{\text{average } Y_{ijk} = X_{ij} \times c \times (X_{ij^*} / X_{ij})^{\beta_1} \times e^{\beta_2 W_{i1} + \beta_3 W_{i2} + \ldots + \beta_p W_{i,p-1}}},
 where
-\eqn{Y_{ijk}} refers to data about the abundance of gene k expressed by taxon j in sample i
-\eqn{X_{ij}} refers to data about the abundance of taxon j in sample i
-\eqn{X_{ij*}} refers to data about the abundance of taxon j* in sample i
-}
-\details{
-We can then interpret, e.g., \eqn{1.01^{beta_1}} as the multiplicative change in the expression-per-unit-coverage of gene k in species j for 1\\% increase in the coverage of species j compared to species j*. With some slightly stronger assumptions about the sampling mechanism, we can also interpret this on the abundance (rather than just coverage) scale
+\eqn{Y_{ijk}} refers to the observed abundance of gene \eqn{k} expressed by taxon \eqn{j} in sample \eqn{i},
+\eqn{X_{ij}} refers to the observed abundance of taxon \eqn{j} in sample \eqn{i},
+\eqn{X_{ij^*}} refers to the observed abundance of taxon \eqn{j^*} in sample \eqn{i}, and
+\eqn{W_{im}} is the value of abiotic covariate \eqn{m} observed in sample \eqn{i}.
+We can interpret \eqn{1.01^{\beta_1}} as the multiplicative change in the expression-per-unit-coverage of gene \eqn{k} in species \eqn{j} for 1\\\% increase in the coverage of species \eqn{j} compared to species \eqn{j^*}. With some slightly stronger assumptions about the sampling mechanism, we can also interpret this on the true cell abundance scale (rather than just the coverage scale).
 }
 \examples{
 my_df <- data.frame(xx = rpois(20, lambda = 400),

--- a/tests/testthat/replicates.R
+++ b/tests/testthat/replicates.R
@@ -13,20 +13,20 @@ test_that("runs with replicates", {
   yy1 <- rpois(n, xx1 * beta0 * (xstar1/xx1)^beta1)
 
   ## works fine
-  expect_type(fit_mgx_model(yy = yy1,
+  expect_type(fit_mgx_model(data.frame(yy = yy1,
                 xstar = xstar1,
-                xx = xx1,
+                xx = xx1),
                 replace_zeros=1),
               "double")
 
   ### does not work
   # Error in eval(cl$data) : object 'my_df' not found
-  expect_type(fit_mgx_model(yy = yy1,
+  expect_type(fit_mgx_model(data.frame(yy = yy1,
                 xstar = xstar1,
-                xx = xx1,
-                replicates = reps,
+                xx = xx1, reps),
+                replicates = "reps",
                 replace_zeros=1),
-              "double")
+              "list")
 
 })
 

--- a/tests/testthat/test-accuracy-correlated.R
+++ b/tests/testthat/test-accuracy-correlated.R
@@ -20,14 +20,14 @@ test_that("reasonably accurate estimates with covariates and correlation", {
   # yy1 <- rpois(n, lambda=eta)
   yy1 <- rnbinom(n, mu=eta, size=eta^2)
 
-  my_df <- tibble(yy1, xx1, predictor = log((xstar1)/(xx1)), xx_covariates1, xx_covariates2, id)
+  my_df <- tibble(yy1, xx1, xstar1, xx_covariates1, xx_covariates2, id)
 
-  output10 <- fit_mgx_model(yy = yy1,
-                            xstar = xstar1,
-                            xx = xx1,
+  output10 <- fit_mgx_model(enviro_df = my_df,
+                            yy = "yy1",
+                            xx = "xx1",
+                            xstar = "xstar1",
                             formula= ~ xx_covariates1 + xx_covariates2,
-                            enviro_df=cbind(xx_covariates1, xx_covariates2),
-                            replicates=id)
+                            replicates="id")
 
   expect_equal(output10["predictor", "Estimate"], expected=beta1, tolerance=0.05)
   expect_equal(output10["xx_covariates1", "Estimate"], expected=beta2, tolerance=0.05)

--- a/tests/testthat/test-accuracy-uncorrelated.R
+++ b/tests/testthat/test-accuracy-uncorrelated.R
@@ -8,10 +8,11 @@ test_that("reasonably accurate estimates", {
   beta0 <- 100
   beta1 <- 1
   yy1 <- rpois(n, xx1 * beta0 * (xstar1/xx1)^beta1)
+  df <- data.frame(yy = yy1,
+                   xstar = xstar1,
+                   xx = xx1)
 
-  output6 <- fit_mgx_model(yy = yy1,
-                           xstar = xstar1,
-                           xx = xx1,
+  output6 <- fit_mgx_model(df,
                            replace_zeros=1)
 
   expect_equal(unname(output6["Estimate"]), expected=beta1, tolerance=abs(0.05*beta1))
@@ -24,9 +25,9 @@ test_that("reasonably accurate estimates", {
   yy1 <- rpois(n, xx1 * beta0 * (xstar1/xx1)^beta1)
   yy1
 
-  output7 <- fit_mgx_model(yy = yy1,
+  output7 <- fit_mgx_model(data.frame(yy = yy1,
                            xstar = xstar1,
-                           xx = xx1,
+                           xx = xx1),
                            replace_zeros=1)
 
   expect_equal(unname(output7["Estimate"]), expected=beta1, tolerance=abs(0.05*beta1))
@@ -48,11 +49,12 @@ test_that("reasonably accurate estimates with covariates", {
   yy1 <- rpois(n, xx1 * beta0 * (xstar1/xx1)^beta1 * exp(beta2 * xx_covariates1 + beta3 * xx_covariates2))
 
   yy1
-  output8 <- fit_mgx_model(yy = yy1,
+  output8 <- fit_mgx_model(data.frame(yy = yy1,
                            xstar = xstar1,
                            xx = xx1,
+                           xx_covariates1,
+                           xx_covariates2),
                            formula= ~ xx_covariates1 + xx_covariates2,
-                           enviro_df=cbind(xx_covariates1, xx_covariates2),
                            replace_zeros=1)
 
   expect_equal(output8["predictor", "Estimate"], expected=beta1, tolerance=abs(0.05*beta1))
@@ -87,12 +89,11 @@ test_that("reasonably accurate estimates with covariates and correlation", {
 
   my_df <- tibble(yy1, xx1, predictor = log((xstar1 + 1)/(xx1 + 1)), xx_covariates1, xx_covariates2, id)
 
-  output9 <- fit_mgx_model(yy = yy1,
+  output9 <- fit_mgx_model(data.frame(yy = yy1,
                 xstar = xstar1,
-                xx = xx1,
+                xx = xx1, xx_covariates1, xx_covariates2, id),
                 formula= ~ xx_covariates1 + xx_covariates2,
-                enviro_df=cbind(xx_covariates1, xx_covariates2),
-                replicates=id,
+                replicates="id",
                 replace_zeros=1)
 
   expect_equal(output9["predictor", "Estimate"], expected=beta1, tolerance=abs(0.05*beta1))

--- a/tests/testthat/test-enviro_covariates.R
+++ b/tests/testthat/test-enviro_covariates.R
@@ -56,4 +56,9 @@ test_that("environmental covariates work", {
   expect_error(fit_mgx_model(new_df, formula = ~ temp + salinity, replicates = "id"),
                "At least one replicate provided is infinite. Please fix this and then rerun.")
 
+  new_df <- df
+  new_df$id <- rnorm(30)
+  expect_error(fit_mgx_model(new_df, formula = ~ temp + salinity + id),
+               "You have a covariate called 'id' in your formula. This is a protected term in `fit_mgx_model`, please use a different name for this covariate")
+
 })

--- a/tests/testthat/test-enviro_covariates.R
+++ b/tests/testthat/test-enviro_covariates.R
@@ -44,4 +44,16 @@ test_that("environmental covariates work", {
   expect_type(out_i_k_rep[1,1], "double")
 
 
+  # test with infinite covariate value
+  new_df <- df
+  new_df$temp[3] <- Inf
+  expect_error(fit_mgx_model(new_df, formula = ~ temp + salinity),
+               "At least one value of covariate temp is infinite. Please fix this and rerun.")
+
+  # test with infinite replicate value
+  new_df$id <- rep(1:5, 6)
+  new_df$id[5] <- -Inf
+  expect_error(fit_mgx_model(new_df, formula = ~ temp + salinity, replicates = "id"),
+               "At least one replicate provided is infinite. Please fix this and then rerun.")
+
 })

--- a/tests/testthat/test-enviro_covariates.R
+++ b/tests/testthat/test-enviro_covariates.R
@@ -16,9 +16,13 @@ test_that("environmental covariates work", {
   temp <- rnorm(nn, mean=23, sd = 2)
   salinity <- rnorm(nn, mean=35, sd = 5)
 
-  expect_silent(out_i_k <- fit_mgx_model(yy_i_k, xstar_i, xx_i,
-                                         formula = ~ temp + salinity,
-                                         enviro_df = cbind(temp, salinity)))
+  df <- data.frame(temp, salinity,
+              yy = yy_i_k,
+              xstar = xstar_i,
+              xx = xx_i)
+
+  expect_silent(out_i_k <- fit_mgx_model(df,
+                                         formula = ~ temp + salinity))
 
   expect_type(out_i_k[1,1], "double")
 
@@ -29,14 +33,14 @@ test_that("environmental covariates work", {
   expect_true(all(out_i_k[1:3, 1] == glm_coefs))
 
 
-  expect_warning(fit_mgx_model(yy_i_k, xstar_i, xx_i))
+  expect_warning(fit_mgx_model(df))
 
 
   ### test with replicates
-  expect_silent(out_i_k_rep <- fit_mgx_model(yy_i_k, xstar_i, xx_i,
+  df$replicates <- rep(LETTERS[1:10], each = 3)
+  expect_silent(out_i_k_rep <- fit_mgx_model(df,
                                              formula = ~ temp + salinity,
-                                             replicates=rep(LETTERS[1:10], each = 3),
-                                             enviro_df = cbind(temp, salinity)))
+                                             replicates="replicates"))
   expect_type(out_i_k_rep[1,1], "double")
 
 

--- a/tests/testthat/test-fit_mgx_model.R
+++ b/tests/testthat/test-fit_mgx_model.R
@@ -2,9 +2,9 @@ n <- 10
 test_that("default model runs", {
 
   set.seed(1)
-  output1 <- fit_mgx_model(yy = rpois(n, lambda=100),
+  output1 <- fit_mgx_model(data.frame(yy = rpois(n, lambda=100),
                            xstar = rpois(n, lambda=100),
-                           xx = rpois(n, lambda=100))
+                           xx = rpois(n, lambda=100)))
   output1
   expect_type(output1, "double")
 
@@ -13,10 +13,11 @@ test_that("default model runs", {
 test_that("weights work", {
 
   set.seed(2)
-  output2 <- fit_mgx_model(yy = rpois(n, lambda=100),
+  output2 <- fit_mgx_model(data.frame(yy = rpois(n, lambda=100),
                            xstar = rpois(n, lambda=100),
                            xx = rpois(n, lambda=100),
-                           wts = rpois(n, lambda=1000))
+                           wts = rpois(n, lambda=1000)),
+                           wts = "wts")
   output2
   expect_type(output2, "double")
 
@@ -30,31 +31,36 @@ test_that("psuedocounts work", {
   xx1 <- rpois(n, lambda=10)
   xx1[2] <- 0
 
-  output2 <- fit_mgx_model(yy = rpois(n, lambda=100),
+  output2 <- fit_mgx_model(data.frame(yy = rpois(n, lambda=100),
                            xstar = rpois(n, lambda=100),
                            xx = xx1,
+                           wts = rpois(n, lambda=100)),
+                           wts = "wts",
                            replace_zeros=1,
-                           wts = rpois(n, lambda=100))
+                           )
 
   expect_type(output2, "double")
 
-  output3 <- fit_mgx_model(yy = rpois(n, lambda=100),
+  output3 <- fit_mgx_model(data.frame(yy = rpois(n, lambda=100),
                            xstar = rpois(n, lambda=100),
                            xx = xx1,
-                           wts = rpois(n, lambda=100))
+                           wts = rpois(n, lambda=100)),
+                           wts = "wts")
 
   expect_type(output2, "double")
 
   yy1 <- rpois(n, lambda=100)
   xstar1 <- rpois(n, lambda=100)
-  output4 <- fit_mgx_model(yy1,
+  output4 <- fit_mgx_model(data.frame(yy1,
                            xstar1,
-                           xx = xx1,
+                           xx = xx1),
+                           yy = "yy1",
+                           xstar = "xstar1",
                            replace_zeros="minimum")
 
-  output5 <- fit_mgx_model(yy = yy1,
+  output5 <- fit_mgx_model(data.frame(yy = yy1,
                            xstar = xstar1,
-                           xx = xx1,
+                           xx = xx1),
                            replace_zeros=min(xx1[xx1>0]))
 
   expect_equal(output4, output5)

--- a/tests/testthat/test-replicates.R
+++ b/tests/testthat/test-replicates.R
@@ -9,26 +9,21 @@ test_that("runs with replicates", {
   reps <- rep(1:4, each = 5)
 
   yy1 <- rpois(n, xx1 * beta0 * (xstar1/xx1)^beta1)
+  df <- data.frame(yy = yy1, xstar = xstar1, xx = xx1, reps = reps)
 
   ## works fine
-  expect_type(fit_mgx_model(yy = yy1,
-                            xstar = xstar1,
-                            xx = xx1,
+  expect_type(fit_mgx_model(df,
                             replace_zeros=1),
               "double")
 
-  expect_type(fit_mgx_model(yy = yy1,
-                            xstar = xstar1,
-                            xx = xx1,
-                            replicates = reps,
+  expect_type(fit_mgx_model(df,
+                            replicates = "reps",
                             replace_zeros=1),
               "list")
 
   # test using jackknife standard errors instead of sandwich standard errors
-  expect_type(fit_mgx_model(yy = yy1,
-                            xstar = xstar1,
-                            xx = xx1,
-                            replicates = reps,
+  expect_type(fit_mgx_model(df,
+                            replicates = "reps",
                             replace_zeros=1,
                             use_jack_se = TRUE),
               "list")


### PR DESCRIPTION
This addresses issue #20, avoiding situations in which there could be different information stored within a data frame compared to in the global environment. In this PR:

- `fit_mgx_model()` is updated so that all inputs (covariates, `yy`, `xx`, `xstar`, optional `replicates`) must be input as part of a data frame
- add example to `fit_mgx_model()` 
- update tests to reflect this new (not backwards compatible) behavior
- update example in readme